### PR TITLE
Implement is_single_data_transfer function

### DIFF
--- a/src/core/dissassembler.rs
+++ b/src/core/dissassembler.rs
@@ -6,3 +6,10 @@ pub fn is_branch_and_branch_exchange(opcode: u32) -> bool {
 
     extracted_format == BRANCH_AND_EXCHANGE_FORMAT
 }
+
+pub fn is_single_data_transfer(opcode: u32) -> bool {
+    const FORMAT_MASK: u32 = 0b1110_0000_0000_0000_0000_0000_0000_0000;
+    const SINGLE_DATA_TRANSFER_PATTERN: u32 = 0b0100_0000_0000_0000_0000_0000_0000_0000;
+
+    (opcode & FORMAT_MASK) == SINGLE_DATA_TRANSFER_PATTERN
+}


### PR DESCRIPTION
   Implements the is_single_data_transfer function for ARM instruction set disassembler

   This PR adds the is_single_data_transfer function to identify Single Data Transfer instructions in the ARM instruction set. The function uses bitwise operations to efficiently check if a given opcode matches the Single Data Transfer pattern.
   
 I have tested this implementation locally, and it's working as expected.
 
<img width="716" alt="Screenshot 2024-10-20 at 9 39 02 PM" src="https://github.com/user-attachments/assets/a3f74286-63e8-4cdd-8118-5e7965e4b5e0">




If you like my contribution and want me to award the bounty, you can do it by buying me the coffees :

https://buymeacoffee.com/aybanda

Thank you, looking forward to contribute to your project!

