### PR TITLE
Reworked register system

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,34 @@
+pub mod register_index {
+    pub const SP_USR: usize = 13;
+    pub const LR_USR: usize = 14;
+    pub const PC: usize = 15;
+    pub const CPSR: usize = 16;
+
+    pub const SP_IRQ: usize = 17;
+    pub const LR_IRQ: usize = 18;
+    pub const SPSR_IRQ: usize = 19;
+
+    pub const SP_FIQ: usize = 25;
+    pub const LR_FIQ: usize = 26;
+    pub const SPSR_FIQ: usize = 27;
+
+    pub const SP_SVC: usize = 28;
+    pub const LR_SVC: usize = 29;
+    pub const SPSR_SVC: usize = 30;
+
+    pub const SP_ABT: usize = 31;
+    pub const LR_ABT: usize = 32;
+    pub const SPSR_ABT: usize = 33;
+
+    pub const SP_UND: usize = 34;
+    pub const LR_UND: usize = 35;
+    pub const SPSR_UND: usize = 36;
+}
+
+pub mod register_initial {
+    pub const SP_USR: u32 = 0x0300_7F00;
+    pub const PC: u32 = 0x0800_0000;
+    pub const CPSR: u32 = 0b0001_0011;
+    pub const SP_IRQ: u32 = 0x0300_7FA0;
+    pub const SP_UND: u32 = 0x0300_7FE0;
+}

--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -54,10 +54,10 @@ impl ARM7TDMI {
 
     fn pass_condition(&self, opcode: u32) -> bool {
         let condition = opcode & CONDITION_MASK;
-        let n = self.get_flag(self.register[16], Flag::N);
-        let z = self.get_flag(self.register[16], Flag::Z);
-        let c = self.get_flag(self.register[16], Flag::C);
-        let v = self.get_flag(self.register[16], Flag::V);
+        let n = self.get_flag(Flag::N);
+        let z = self.get_flag(Flag::Z);
+        let c = self.get_flag(Flag::C);
+        let v = self.get_flag(Flag::V);
     
         match condition {
             condition_codes::EQ => z,

--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -54,10 +54,10 @@ impl ARM7TDMI {
 
     fn pass_condition(&self, opcode: u32) -> bool {
         let condition = opcode & CONDITION_MASK;
-        let n = get_flag(self.register[16], Flag::N);
-        let z = get_flag(self.register[16], Flag::Z);
-        let c = get_flag(self.register[16], Flag::C);
-        let v = get_flag(self.register[16], Flag::V);
+        let n = self.get_flag(self.register[16], Flag::N);
+        let z = self.get_flag(self.register[16], Flag::Z);
+        let c = self.get_flag(self.register[16], Flag::C);
+        let v = self.get_flag(self.register[16], Flag::V);
     
         match condition {
             condition_codes::EQ => z,

--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -8,18 +8,18 @@ use crate::constants::condition_codes;
 
 pub struct ARM7TDMI {
     // register indexes are as follows
-    // low regs are 0-7
-    // high general-purpose regs user/system are 8-12
-    // fiq registers are 20-26
+    // low regs are 0-7 inclusive
+    // usr/sys high general-purpose regs are 8-12 inclusive
+    // fiq high general-purpose regs are 20-24 inclusive
     register: [u32; 37],
-    mode_register: [usize; 17], // this array is of indexes for register
+    idx: [usize; 17], // this array is of indexes for register
 }
 
 impl Default for ARM7TDMI {
     fn default() -> ARM7TDMI {
         let mut cpu = ARM7TDMI { 
             register: [0; 37],
-            mode_register: [0, 1, 2, 3, 4, 5, 6, 7,
+            idx: [0, 1, 2, 3, 4, 5, 6, 7,
             8, 9, 10, 11, 12, 
             register_index::SP_USR, 
             register_index::LR_USR, 
@@ -34,6 +34,49 @@ impl Default for ARM7TDMI {
         cpu.register[34] = register_initial::SP_UND;
 
         cpu
+    }
+}
+
+impl ARM7TDMI {
+    fn set_flag(&mut self, flag: Flag, bit: bool) {
+        let mask = flag.get_mask();
+        if bit == true {
+            self.register[16] |= mask;
+        } else {
+            self.register[16] &= !mask;
+        }
+    }
+
+    fn get_flag(&self, flag: Flag) -> bool {
+        let mask = flag.get_mask();
+        (self.register[16] & mask) != 0
+    }
+
+    fn pass_condition(&self, opcode: u32) -> bool {
+        let condition = opcode & CONDITION_MASK;
+        let n = get_flag(self.register[16], Flag::N);
+        let z = get_flag(self.register[16], Flag::Z);
+        let c = get_flag(self.register[16], Flag::C);
+        let v = get_flag(self.register[16], Flag::V);
+    
+        match condition {
+            condition_codes::EQ => z,
+            condition_codes::NQ => !z,
+            condition_codes::CS_HS => c,
+            condition_codes::CC_LO => !c,
+            condition_codes::MI => n,
+            condition_codes::PL => !n,
+            condition_codes::VS => v,
+            condition_codes::VC => !v,
+            condition_codes::HI => c && !z,
+            condition_codes::LS => !c && z,
+            condition_codes::GE => n == v,
+            condition_codes::LT => n != v,
+            condition_codes::GT => !z && (n == v),
+            condition_codes::LE => z && (n != v),
+            condition_codes::AL => true,
+            _ => false,
+        }
     }
 }
 
@@ -58,45 +101,9 @@ impl Flag {
 }
 
 /// TODO: cpsr hould be replaced with the actual instance vairable 
-fn set_flag(cpsr: &mut u32, flag: Flag, bit: bool) {
-    let mask = flag.get_mask();
-    if bit == true {
-        *cpsr |= mask;
-    } else {
-        *cpsr &= !mask;
-    }
-}
+
 
 /// TODO: cpsr should be replaced with the actual instance vairable 
-fn get_flag(cpsr: u32, flag: Flag) -> bool {
-    let mask = flag.get_mask();
-    (cpsr & mask) != 0
-}
+
 
 /// TODO: cpsr should be replaced with the actual instance vairable 
-fn pass_condition(opcode: u32, cpsr: u32) -> bool {
-    let condition = opcode & CONDITION_MASK;
-    let n = get_flag(cpsr, Flag::N);
-    let z = get_flag(cpsr, Flag::Z);
-    let c = get_flag(cpsr, Flag::C);
-    let v = get_flag(cpsr, Flag::V);
-
-    match condition {
-        condition_codes::EQ => z,
-        condition_codes::NQ => !z,
-        condition_codes::CS_HS => c,
-        condition_codes::CC_LO => !c,
-        condition_codes::MI => n,
-        condition_codes::PL => !n,
-        condition_codes::VS => v,
-        condition_codes::VC => !v,
-        condition_codes::HI => c && !z,
-        condition_codes::LS => !c && z,
-        condition_codes::GE => n == v,
-        condition_codes::LT => n != v,
-        condition_codes::GT => !z && (n == v),
-        condition_codes::LE => z && (n != v),
-        condition_codes::AL => true,
-        _ => false,
-    }
-}

--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -99,11 +99,3 @@ impl Flag {
         }
     }
 }
-
-/// TODO: cpsr hould be replaced with the actual instance vairable 
-
-
-/// TODO: cpsr should be replaced with the actual instance vairable 
-
-
-/// TODO: cpsr should be replaced with the actual instance vairable 

--- a/src/core/cpu.rs
+++ b/src/core/cpu.rs
@@ -1,15 +1,13 @@
 use crate::core::bus::Memory;
 use crate::core::bus::BusAccess;
+use crate::constants::register_index;
+use crate::constants::register_initial;
 
 pub struct ARM7TDMI {
     // register indexes are as follows
     // low regs are 0-7
-    // high regs user/system are 8-16
-    // r13_irq, r14_irq, and spsr_irq are 17, 18, and 19
-    // fiq registers are 20-26, spsr_irq is 27
-    // r13_svc, r14_svc, and spsr_svc are 28, 29, and 30
-    // r13_abt, r14_abt, and spsr_abt are 31, 32, and 33
-    // r13_und, r14_und, and r15_und are 34, 35, and 36
+    // high general-purpose regs user/system are 8-12
+    // fiq registers are 20-26
     register: [u32; 37],
     mode_register: [usize; 17], // this array is of indexes for register
 }
@@ -19,14 +17,18 @@ impl Default for ARM7TDMI {
         let mut cpu = ARM7TDMI { 
             register: [0; 37],
             mode_register: [0, 1, 2, 3, 4, 5, 6, 7,
-            8, 9, 10, 11, 12, 13, 14, 15, 16],
+            8, 9, 10, 11, 12, 
+            register_index::SP_USR, 
+            register_index::LR_USR, 
+            register_index::PC, 
+            register_index::CPSR],
         };
 
-        cpu.register[13] = 0x0300_7F00;
-        cpu.register[15] = 0x0800_0000;
-        cpu.register[16] = 0b0000_0000_0000_0000_0000_0000_0001_0011;
-        cpu.register[17] = 0x0300_7FA0;
-        cpu.register[34] = 0x0300_7FE0;
+        cpu.register[13] = register_initial::SP_USR;
+        cpu.register[15] = register_initial::PC;
+        cpu.register[16] = register_initial::CPSR;
+        cpu.register[17] = register_initial::SP_IRQ;
+        cpu.register[34] = register_initial::SP_UND;
 
         cpu
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod core;
+mod constants;
 
 use crate::core::bus::Memory;
 use crate::core::bus::BusAccess;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 */
 
-/* TEST 2 - CPU ACCESS */
+/* TEST 2 - CPU ACCESS
 fn main() {
     let mut memory = Memory::new();
     let mut cpu: ARM7TDMI = Default::default();
@@ -41,4 +41,9 @@ fn main() {
     
     cpu.sbyte(&mut memory, 0x0300_0001);
     println!("{:#04x}", memory.rbyte(0x0300_0001));
+}
+*/
+
+fn main() {
+    println!("Test");
 }


### PR DESCRIPTION
Made register system easier to work with programmatically.
The `register` array contains the data for all registers banked or not.
The `mode_register` array contains indexes to the currently used arrays.
When switching modes, simply change the elements in mode_register to correspond with the banked register indexes.